### PR TITLE
fix for centos7

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,4 +4,4 @@
   when: ansible_os_family == 'RedHat' and ansible_distribution_version | version_compare('6.0', '<')
 
 - include: RedHat-6.yml
-  when: ansible_os_family == 'RedHat' and ansible_distribution_version | version_compare('6.0', '>=')
+  when: ansible_os_family == 'RedHat' and ansible_distribution_version | version_compare('6.0', '=')


### PR DESCRIPTION
This change prevents clobbering centos7 epel repo with centos6 repo.  
